### PR TITLE
Aaaaaaaaaaaadventure compatibility

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,49 @@
+name: Optimize map and deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - name: Install jq and curl
+        run: |
+          sudo apt-get update
+          sudo apt-get install jq curl
+        
+      - name: Aaaaaaaaaaaadventure Slug Replacement Script
+        run: |
+          curl https://aaaaaaaaaaaadventu.re/replace_slugs2.sh -o replace_slugs2.sh
+          chmod +x replace_slugs2.sh
+          ./replace_slugs2.sh *.json hbf/*.json
+      - name: Optimize map
+        uses: thecodingmachine/map-optimizer-action@master
+
+      - name: Bash
+        run: |
+          ls -al
+          git config --global user.email "d.negrier@thecodingmachine.com"
+          git config --global user.name "David Négrier"
+          git checkout master
+          git commit -am "Adding files"
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: . # The folder the action should deploy.
+          BASE_BRANCH: master
+
+      - name: Bash2
+        run: |
+          ls -al

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,7 +3,7 @@ name: Optimize map and deploy
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
 


### PR DESCRIPTION
Das fügt eine Github Action (kopiert vom Metalab https://github.com/Metalab/maptest/blob/master/.github/workflows/build-and-deploy.yml) hinzu, die bei jedem commit in den main branch die slugs (world://blablab/bla.json) ersetzt und das ergebnis in den gh-pages branch commited, d.h. die Map ist dann auch außerhalb des rC3 nutzbar.

Achtung! Damit das funktioniert muss nachher auch noch Github Pages mit Branch gh-pages aktiviert werden.